### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rlammers/FlightPlanner/security/code-scanning/1](https://github.com/rlammers/FlightPlanner/security/code-scanning/1)

Add an explicit `permissions` block to the workflow YAML so `GITHUB_TOKEN` is constrained to only what this workflow needs.  
Best fix here: define workflow-level permissions directly under `on`, before `jobs`, with:

- `contents: read`

This is sufficient for `actions/checkout` and linting source files, and it preserves existing behavior while tightening token scope.

Change needed in:
- `.github/workflows/pylint.yml`  
  Insert a new top-level block between lines 3 and 5 (after `on: [push]` and before `jobs:`).

No imports, methods, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
